### PR TITLE
Pin the numpy dependency for koverage env

### DIFF
--- a/reneo/workflow/envs/koverage.yaml
+++ b/reneo/workflow/envs/koverage.yaml
@@ -6,3 +6,4 @@ dependencies:
     - pip
     - pip:
         - koverage>=0.1.8
+        - numpy==1.26.4


### PR DESCRIPTION
Hi @Vini2 , 

Congratulations on the great tool!

I am trying to integrate `reneo` into `everest-nf` and came across an issue during runtime 

```
ValueError: numpy.dtype size changed, may indicate binary incompatibility. Expected 96 from C header, got 88 from PyObject
```

It seems that the problem might be the fact that `pandas` relies on a minimal version of numpy but not the maximum and since there are some breaking changes in `numpy 2.0.0` the error propogates further up.


Reference: https://stackoverflow.com/a/78641304/6482586 

CC @agudeloromero